### PR TITLE
Multithread fractal

### DIFF
--- a/go/fractal/Multithread.md
+++ b/go/fractal/Multithread.md
@@ -1,0 +1,9 @@
+The fractal generation is embarrassingly parallel, since it just iterates each pixel's coordinates separately
+till it finds its destination, so it's an easy win to split it into goroutines by pixel.
+
+The fastest method is to keep a global image.RGBA, and have each goroutine set pixel colors.
+This is safe (https://stackoverflow.com/questions/49879322/can-i-concurrently-write-different-slice-elements).
+
+However, it's not safe with the arbitrary integer polynomial fractal functions returned by
+NewPolyFractal(coefs). Those tracks the polynomial roots as they are found in a slice `roots`
+wrapped in the closure. Having different goroutines calling roots = append(roots, z) is a race.

--- a/go/fractal/Multithread.md
+++ b/go/fractal/Multithread.md
@@ -7,3 +7,5 @@ This is safe (https://stackoverflow.com/questions/49879322/can-i-concurrently-wr
 However, it's not safe with the arbitrary integer polynomial fractal functions returned by
 NewPolyFractal(coefs). Those tracks the polynomial roots as they are found in a slice `roots`
 wrapped in the closure. Having different goroutines calling roots = append(roots, z) is a race.
+
+A mutex lock was added around checking the roots, which will reduce the benefits of parallelization.

--- a/go/fractal/Multithread.md
+++ b/go/fractal/Multithread.md
@@ -9,3 +9,21 @@ NewPolyFractal(coefs). Those tracks the polynomial roots as they are found in a 
 wrapped in the closure. Having different goroutines calling roots = append(roots, z) is a race.
 
 A mutex lock was added around checking the roots, which will reduce the benefits of parallelization.
+
+Timings:
+For a single request at a time, paralellization improved times:
+Mandelbrot: 0.2s to 0.1s
+7th roots of unity: 2.1s to 0.8s
+Newton fractal for 2-2x+x^3: 0.45s to 0.2s
+
+The Newton fractal is the one requiring the mutex lock around the roots access,
+so even with that contention the speedup is considerable.
+
+The outputs for the Newton fractal have different colors, however, since the order of root discovery changes.
+It is deterministic for a single-threaded program.
+
+For handling five requests at once, the benefits are less, as you might expect.
+The following times are for the last request to complete when five are started simulteneously.
+Mandelbrot: 0.36s to 0.32s
+7th roots of unity: 3.0s to 2.5s
+Newton fractal for 2-2x+x^3: 0.7s to 0.6s

--- a/go/fractal/fractal.go
+++ b/go/fractal/fractal.go
@@ -9,11 +9,13 @@ import (
 	"log"
 	"math"
 	"math/cmplx"
+	"sync"
 )
 
 const (
 	xmin, ymin, xmax, ymax = -2, -2, +2, +2
 	width, height          = 1024, 1024
+	numproc                = 4
 )
 
 const thresh = 0.0001
@@ -22,14 +24,22 @@ type colorfunc func(complex128) color.Color
 
 func WritePNG(w io.Writer, f colorfunc) {
 	img := image.NewRGBA(image.Rect(0, 0, width, height))
-	for py := 0; py < height; py++ {
-		y := float64(py)/height*(ymax-ymin) + ymin
-		for px := 0; px < width; px++ {
-			x := float64(px)/width*(xmax-xmin) + xmin
-			z := complex(x, y)
-			img.Set(px, py, f(z))
-		}
+	var wg sync.WaitGroup
+	wg.Add(numproc)
+	for i := 0; i < numproc; i++ {
+		go func(id int) {
+			defer wg.Done()
+			for py := id; py < height; py += numproc {
+				y := float64(py)/height*(ymax-ymin) + ymin
+				for px := 0; px < width; px++ {
+					x := float64(px)/width*(xmax-xmin) + xmin
+					z := complex(x, y)
+					img.Set(px, py, f(z))
+				}
+			}
+		}(i)
 	}
+	wg.Wait()
 	png.Encode(w, img)
 }
 

--- a/go/fractal/fractal.go
+++ b/go/fractal/fractal.go
@@ -141,6 +141,7 @@ func (coefs IPoly) differentiate() IPoly {
 
 func NewPolyFractal(coefs IPoly) colorfunc {
 	const iterations = 200
+	var mu sync.Mutex
 	roots := make([]complex128, 0, len(coefs))
 	df := coefs.differentiate()
 	return func(z complex128) color.Color {
@@ -149,13 +150,16 @@ func NewPolyFractal(coefs IPoly) colorfunc {
 			dif := cmplx.Abs(newz - z)
 			z = newz
 			if dif < thresh {
+				mu.Lock()
 				for i, root := range roots {
 					if cmplx.Abs(z-root) < thresh {
+						mu.Unlock()
 						return thecolor(i, iter)
 					}
 				}
 				// no nearby root already in roots
 				roots = append(roots, z)
+				mu.Unlock()
 				return thecolor(len(roots)-1, iter)
 			}
 		}


### PR DESCRIPTION
Multithreading turns out to be beneficial for all the use cases, even the Newton fractals that need to modify external state, and even when handling many requests at once.